### PR TITLE
✨ implement -nocablelength flag

### DIFF
--- a/cotter.cpp
+++ b/cotter.cpp
@@ -55,6 +55,7 @@ Cotter::Cotter() :
 	_applySBGains(true),
 	_flagDCChannels(true),
 	_skipWriting(false),
+    _doCorrectCableLength(true),
 	_offlineGPUBoxFormat(false),
 	_customRARad(0.0),
 	_customDecRad(0.0),
@@ -894,10 +895,12 @@ void Cotter::processBaseline(size_t antenna1, size_t antenna2, aoflagger::Strate
 	}
 	
 	// Correct cable delay
+    if(_doCorrectCableLength) {
 	correctCableLength(imageSet, 0, input2X.cableLenDelta - input1X.cableLenDelta);
 	correctCableLength(imageSet, 1, input2Y.cableLenDelta - input1X.cableLenDelta);
 	correctCableLength(imageSet, 2, input2X.cableLenDelta - input1Y.cableLenDelta);
 	correctCableLength(imageSet, 3, input2Y.cableLenDelta - input1Y.cableLenDelta);
+    }
 	
 	// Correct passband
 	for(size_t i=0; i!=8; ++i)

--- a/cotter.h
+++ b/cotter.h
@@ -55,6 +55,7 @@ class Cotter : private UVWCalculater
 		}
 		void SetDoAlign(bool doAlign) { _doAlign = doAlign; }
 		void SetDoFlagMissingSubbands(bool doFlagMissingSubbands) { _doFlagMissingSubbands = doFlagMissingSubbands; }
+        void SetDoCorrectCableLength(bool doCorrectCableLength) { _doCorrectCableLength = doCorrectCableLength; }
 		void SetSubbandCount(size_t subbandCount) { _subbandCount = subbandCount; }
 		void SetRemoveFlaggedAntennae(bool removeFlaggedAntennae) { _removeFlaggedAntennae = removeFlaggedAntennae; }
 		void SetRemoveAutoCorrelations(bool removeAutoCorrelations) { _removeAutoCorrelations = removeAutoCorrelations; }
@@ -136,7 +137,7 @@ class Cotter : private UVWCalculater
 		aoflagger::FlagMask _correlatorMask, _fullysetMask;
 		
 		bool _disableGeometricCorrections, _removeFlaggedAntennae, _removeAutoCorrelations, _flagAutos;
-		bool _overridePhaseCentre, _doAlign, _doFlagMissingSubbands, _applySBGains, _flagDCChannels, _skipWriting;
+		bool _overridePhaseCentre, _doAlign, _doFlagMissingSubbands, _applySBGains, _flagDCChannels, _skipWriting, _doCorrectCableLength;
 		bool _offlineGPUBoxFormat;
 		long double _customRARad, _customDecRad;
 		double _initDurationToFlag, _endDurationToFlag;

--- a/main.cpp
+++ b/main.cpp
@@ -88,6 +88,7 @@ void usage()
 	"  -allowmissing      Do not abort when not all GPU box files are available (default is to abort).\n"
 	"  -flagdcchannels    Flag the centre channel of each sub-band (currently the default).\n"
 	"  -noflagdcchannels  Do not flag the centre channel of each sub-band.\n"
+    "  -nocablelength     Do not perform cable length corrections.\n"
 	"  -centre <ra> <dec> Set alternative phase centre, e.g. -centre 00h00m00.0s 00d00m00.0s.\n"
 	"  -usepcentre        Centre on pointing centre.\n"
 	"  -sbcount <count>   Read/processes the first given number of sub-bands.\n"
@@ -268,6 +269,10 @@ int cotterMain(int argc, const char* const* argv)
 			else if(param == "noflagdcchannels")
 			{
 				cotter.SetFlagDCChannels(false);
+			}
+			else if(param == "nocablelength")
+			{
+				cotter.SetDoCorrectCableLength(false);
 			}
 			else if(param == "timeres")
 			{


### PR DESCRIPTION
Enabling flag will cause Cotter to not perform cable length corrections.